### PR TITLE
added example to Register.MessageHook

### DIFF
--- a/api/hub.rst
+++ b/api/hub.rst
@@ -164,6 +164,16 @@ Methods
     `New Math` messages are sent).  When the message equals the
     `type`, the `callback` will be called with the message as its
     parameter.
+    
+    This can be used to listen to parsing errors or processing errors which would otherwise fail silently.
+	  
+	  MathJax.Hub.Register.MessageHook("TeX Jax - parse error",function (message) {
+	    // do something with the error.  message[1] will contain the data about the error.
+	  });
+	  
+	  MathJax.Hub.Register.MessageHook("Math Processing Error",function (message) {
+	    //  do something with the error.  message[2] is the Error object that records the problem.
+	  });
 
     :Parameters:
         - **type** --- a string indicating the message to look for


### PR DESCRIPTION
which shows how it can be used to watch for errors within MathJax
